### PR TITLE
【FEAT】タブを分ける

### DIFF
--- a/demomoni-remake-ios.xcodeproj/project.pbxproj
+++ b/demomoni-remake-ios.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		4FDD2E502BE3BA0F00B91618 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDD2E4F2BE3BA0F00B91618 /* ContentView.swift */; };
 		4FDD2E522BE3BA1000B91618 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4FDD2E512BE3BA1000B91618 /* Assets.xcassets */; };
 		4FDD2E562BE3BA1000B91618 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4FDD2E552BE3BA1000B91618 /* Preview Assets.xcassets */; };
+		4FE84FB12BE3C8EA00ED2101 /* RiddleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE84FB02BE3C8EA00ED2101 /* RiddleView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -20,6 +21,7 @@
 		4FDD2E512BE3BA1000B91618 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		4FDD2E532BE3BA1000B91618 /* demomoni_remake_ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = demomoni_remake_ios.entitlements; sourceTree = "<group>"; };
 		4FDD2E552BE3BA1000B91618 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		4FE84FB02BE3C8EA00ED2101 /* RiddleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RiddleView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -54,6 +56,7 @@
 			children = (
 				4FDD2E4D2BE3BA0F00B91618 /* demomoni_remake_iosApp.swift */,
 				4FDD2E4F2BE3BA0F00B91618 /* ContentView.swift */,
+				4FE84FAF2BE3C8C900ED2101 /* Riddle */,
 				4FDD2E512BE3BA1000B91618 /* Assets.xcassets */,
 				4FDD2E532BE3BA1000B91618 /* demomoni_remake_ios.entitlements */,
 				4FDD2E542BE3BA1000B91618 /* Preview Content */,
@@ -67,6 +70,14 @@
 				4FDD2E552BE3BA1000B91618 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		4FE84FAF2BE3C8C900ED2101 /* Riddle */ = {
+			isa = PBXGroup;
+			children = (
+				4FE84FB02BE3C8EA00ED2101 /* RiddleView.swift */,
+			);
+			path = Riddle;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -141,6 +152,7 @@
 			files = (
 				4FDD2E502BE3BA0F00B91618 /* ContentView.swift in Sources */,
 				4FDD2E4E2BE3BA0F00B91618 /* demomoni_remake_iosApp.swift in Sources */,
+				4FE84FB12BE3C8EA00ED2101 /* RiddleView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/demomoni-remake-ios.xcodeproj/project.pbxproj
+++ b/demomoni-remake-ios.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		4FDD2E522BE3BA1000B91618 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4FDD2E512BE3BA1000B91618 /* Assets.xcassets */; };
 		4FDD2E562BE3BA1000B91618 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4FDD2E552BE3BA1000B91618 /* Preview Assets.xcassets */; };
 		4FE84FB12BE3C8EA00ED2101 /* RiddleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE84FB02BE3C8EA00ED2101 /* RiddleView.swift */; };
+		4FE84FB42BE3C96B00ED2101 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE84FB32BE3C96B00ED2101 /* SearchView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -22,6 +23,7 @@
 		4FDD2E532BE3BA1000B91618 /* demomoni_remake_ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = demomoni_remake_ios.entitlements; sourceTree = "<group>"; };
 		4FDD2E552BE3BA1000B91618 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		4FE84FB02BE3C8EA00ED2101 /* RiddleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RiddleView.swift; sourceTree = "<group>"; };
+		4FE84FB32BE3C96B00ED2101 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -57,6 +59,7 @@
 				4FDD2E4D2BE3BA0F00B91618 /* demomoni_remake_iosApp.swift */,
 				4FDD2E4F2BE3BA0F00B91618 /* ContentView.swift */,
 				4FE84FAF2BE3C8C900ED2101 /* Riddle */,
+				4FE84FB22BE3C95900ED2101 /* Search */,
 				4FDD2E512BE3BA1000B91618 /* Assets.xcassets */,
 				4FDD2E532BE3BA1000B91618 /* demomoni_remake_ios.entitlements */,
 				4FDD2E542BE3BA1000B91618 /* Preview Content */,
@@ -78,6 +81,14 @@
 				4FE84FB02BE3C8EA00ED2101 /* RiddleView.swift */,
 			);
 			path = Riddle;
+			sourceTree = "<group>";
+		};
+		4FE84FB22BE3C95900ED2101 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				4FE84FB32BE3C96B00ED2101 /* SearchView.swift */,
+			);
+			path = Search;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -150,6 +161,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4FE84FB42BE3C96B00ED2101 /* SearchView.swift in Sources */,
 				4FDD2E502BE3BA0F00B91618 /* ContentView.swift in Sources */,
 				4FDD2E4E2BE3BA0F00B91618 /* demomoni_remake_iosApp.swift in Sources */,
 				4FE84FB12BE3C8EA00ED2101 /* RiddleView.swift in Sources */,

--- a/demomoni-remake-ios.xcodeproj/project.pbxproj
+++ b/demomoni-remake-ios.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		4FDD2E562BE3BA1000B91618 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4FDD2E552BE3BA1000B91618 /* Preview Assets.xcassets */; };
 		4FE84FB12BE3C8EA00ED2101 /* RiddleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE84FB02BE3C8EA00ED2101 /* RiddleView.swift */; };
 		4FE84FB42BE3C96B00ED2101 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE84FB32BE3C96B00ED2101 /* SearchView.swift */; };
+		4FE84FB72BE3CA7E00ED2101 /* PieceListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE84FB62BE3CA7E00ED2101 /* PieceListView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +25,7 @@
 		4FDD2E552BE3BA1000B91618 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		4FE84FB02BE3C8EA00ED2101 /* RiddleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RiddleView.swift; sourceTree = "<group>"; };
 		4FE84FB32BE3C96B00ED2101 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
+		4FE84FB62BE3CA7E00ED2101 /* PieceListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceListView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,6 +62,7 @@
 				4FDD2E4F2BE3BA0F00B91618 /* ContentView.swift */,
 				4FE84FAF2BE3C8C900ED2101 /* Riddle */,
 				4FE84FB22BE3C95900ED2101 /* Search */,
+				4FE84FB52BE3CA4400ED2101 /* PieceList */,
 				4FDD2E512BE3BA1000B91618 /* Assets.xcassets */,
 				4FDD2E532BE3BA1000B91618 /* demomoni_remake_ios.entitlements */,
 				4FDD2E542BE3BA1000B91618 /* Preview Content */,
@@ -89,6 +92,14 @@
 				4FE84FB32BE3C96B00ED2101 /* SearchView.swift */,
 			);
 			path = Search;
+			sourceTree = "<group>";
+		};
+		4FE84FB52BE3CA4400ED2101 /* PieceList */ = {
+			isa = PBXGroup;
+			children = (
+				4FE84FB62BE3CA7E00ED2101 /* PieceListView.swift */,
+			);
+			path = PieceList;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -163,6 +174,7 @@
 			files = (
 				4FE84FB42BE3C96B00ED2101 /* SearchView.swift in Sources */,
 				4FDD2E502BE3BA0F00B91618 /* ContentView.swift in Sources */,
+				4FE84FB72BE3CA7E00ED2101 /* PieceListView.swift in Sources */,
 				4FDD2E4E2BE3BA0F00B91618 /* demomoni_remake_iosApp.swift in Sources */,
 				4FE84FB12BE3C8EA00ED2101 /* RiddleView.swift in Sources */,
 			);

--- a/demomoni-remake-ios/ContentView.swift
+++ b/demomoni-remake-ios/ContentView.swift
@@ -8,13 +8,18 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State var selection = 2
+    
     var body: some View {
-        TabView {
+        TabView(selection: $selection) {
             RiddleView()
+                .tag(1)
             
             SearchView()
+                .tag(2)
             
             PieceListView()
+                .tag(3)
         }
     }
 }

--- a/demomoni-remake-ios/ContentView.swift
+++ b/demomoni-remake-ios/ContentView.swift
@@ -10,11 +10,8 @@ import SwiftUI
 struct ContentView: View {
     var body: some View {
         TabView {
-            Text("なぞなぞ画面")
-                .tabItem {
-                    Image(systemName: "questionmark.bubble.fill")
-                    Text("なぞなぞ")
-                }
+            RiddleView()
+            
             Text("さがす画面")
                 .tabItem {
                     Image(systemName: "magnifyingglass")

--- a/demomoni-remake-ios/ContentView.swift
+++ b/demomoni-remake-ios/ContentView.swift
@@ -9,13 +9,23 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, でももに！")
+        TabView {
+            Text("なぞなぞ画面")
+                .tabItem {
+                    Image(systemName: "message.fill")
+                    Text("メッセージ")
+                }
+            Text("さがす画面")
+                .tabItem {
+                    Image(systemName: "magnifyingglass")
+                    Text("さがす")
+                }
+            Text("いちらん画面")
+                .tabItem {
+                    Image(systemName: "face.smiling.fill")
+                    Text("いちらん")
+                }
         }
-        .padding()
     }
 }
 

--- a/demomoni-remake-ios/ContentView.swift
+++ b/demomoni-remake-ios/ContentView.swift
@@ -12,8 +12,8 @@ struct ContentView: View {
         TabView {
             Text("なぞなぞ画面")
                 .tabItem {
-                    Image(systemName: "message.fill")
-                    Text("メッセージ")
+                    Image(systemName: "questionmark.bubble.fill")
+                    Text("なぞなぞ")
                 }
             Text("さがす画面")
                 .tabItem {
@@ -22,7 +22,7 @@ struct ContentView: View {
                 }
             Text("いちらん画面")
                 .tabItem {
-                    Image(systemName: "face.smiling.fill")
+                    Image(systemName: "puzzlepiece.extension")
                     Text("いちらん")
                 }
         }

--- a/demomoni-remake-ios/ContentView.swift
+++ b/demomoni-remake-ios/ContentView.swift
@@ -14,11 +14,7 @@ struct ContentView: View {
             
             SearchView()
             
-            Text("いちらん画面")
-                .tabItem {
-                    Image(systemName: "puzzlepiece.extension")
-                    Text("いちらん")
-                }
+            PieceListView()
         }
     }
 }

--- a/demomoni-remake-ios/ContentView.swift
+++ b/demomoni-remake-ios/ContentView.swift
@@ -12,11 +12,8 @@ struct ContentView: View {
         TabView {
             RiddleView()
             
-            Text("さがす画面")
-                .tabItem {
-                    Image(systemName: "magnifyingglass")
-                    Text("さがす")
-                }
+            SearchView()
+            
             Text("いちらん画面")
                 .tabItem {
                     Image(systemName: "puzzlepiece.extension")

--- a/demomoni-remake-ios/PieceList/PieceListView.swift
+++ b/demomoni-remake-ios/PieceList/PieceListView.swift
@@ -1,0 +1,18 @@
+//
+//  PieceListView.swift
+//  demomoni-remake-ios
+//
+//  Created by 村石 拓海 on 2024/05/02.
+//
+
+import SwiftUI
+
+struct PieceListView: View {
+    var body: some View {
+        Text("いちらん画面")
+            .tabItem {
+                Image(systemName: "puzzlepiece.extension")
+                Text("いちらん")
+            }
+    }
+}

--- a/demomoni-remake-ios/Riddle/RiddleView.swift
+++ b/demomoni-remake-ios/Riddle/RiddleView.swift
@@ -1,0 +1,18 @@
+//
+//  RiddleView.swift
+//  demomoni-remake-ios
+//
+//  Created by 村石 拓海 on 2024/05/02.
+//
+
+import SwiftUI
+
+struct RiddleView: View {
+    var body: some View {
+        Text("なぞなぞ画面")
+            .tabItem {
+                Image(systemName: "questionmark.bubble.fill")
+                Text("なぞなぞ")
+            }
+    }
+}

--- a/demomoni-remake-ios/Search/SearchView.swift
+++ b/demomoni-remake-ios/Search/SearchView.swift
@@ -1,0 +1,18 @@
+//
+//  SearchView.swift
+//  demomoni-remake-ios
+//
+//  Created by 村石 拓海 on 2024/05/02.
+//
+
+import SwiftUI
+
+struct SearchView: View {
+    var body: some View {
+        Text("さがす画面")
+            .tabItem {
+                Image(systemName: "magnifyingglass")
+                Text("さがす")
+            }
+    }
+}


### PR DESCRIPTION
## 概要
- タブを3つに分ける
- デフォルトのタブを「さがす」 にする

## 画面差分
|なぞなぞ|さがす|いちらん|
|:--:|:--:|:--:|
|![simulator_screenshot_C892C1B7-A3A1-43A5-B324-07B8F69A2CEF](https://github.com/BeaconFun4/demomoni-remake-ios/assets/40351476/94871a7e-4f23-48f8-9cae-09b0d0d2d0cb)|![simulator_screenshot_DC4ADD1B-151F-4765-805F-24DBAB4967BE](https://github.com/BeaconFun4/demomoni-remake-ios/assets/40351476/32479635-c27f-4ae8-b4ab-76f90dd4f054)|![simulator_screenshot_F36BF980-6586-417C-8A92-359BFF526CAA](https://github.com/BeaconFun4/demomoni-remake-ios/assets/40351476/d9c825fa-eca0-407b-acf2-70eda46667af)|

## 関連するIssue
- resolve #6 